### PR TITLE
Packaging fix

### DIFF
--- a/components/modal.vue
+++ b/components/modal.vue
@@ -31,7 +31,6 @@
 <script lang='coffee'>
 import Shade from './shade'
 import Contents from './contents'
-import TestData from '~/components/demos/test'
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 export default
@@ -39,7 +38,6 @@ export default
 	components: {
 		Shade,
 		Contents
-		TestData
 	}
 
 	props:

--- a/components/modal.vue
+++ b/components/modal.vue
@@ -22,9 +22,7 @@
 			:scrollLock='scrollLock'
 			:transition='transition')
 
-			//- TODO: convert this to a slot
-			//- slot
-			test-data
+			slot
 
 </template>
 

--- a/demo/components/demos/modal.vue
+++ b/demo/components/demos/modal.vue
@@ -79,11 +79,8 @@ div
 </template>
 
 <script lang='coffee'>
-import Modal from '/components/cloak-modal'
-
+import TestModal from './test'
 export default
-
-  components: { Modal }
 
   data: ->
     opened: false
@@ -99,7 +96,7 @@ export default
 
   methods:
     open: () ->
-      await @$mountOnBody Modal,
+      await @$mountOnBody TestModal,
         parent: @
         propsData:
           position: @position

--- a/demo/components/demos/test.vue
+++ b/demo/components/demos/test.vue
@@ -1,16 +1,16 @@
 <template lang='pug'>
-  div
+  cloak-modal(v-bind='$props')
     h3 Modal Contents
     p Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia venenatis lectus, ac cursus ligula. Sed nec enim urna. Nullam congue eros elit, eget consectetur nunc accumsan quis.
     button Button
 </template>
 
 <script lang='coffee'>
-
+import CloakModal from '../../../components/modal'
 export default
 
-  data: ->
-    loaded: true
+  # Support all props
+  props: { ...CloakModal.props }
 
 </script>
 

--- a/nuxt.js
+++ b/nuxt.js
@@ -1,11 +1,15 @@
 import { join } from 'path'
 export default function() {
 
+	// Have Nuxt transpile resources
+	this.options.build.transpile.push('@cloak-app/modal')
+
 	// Allow components to be auto-imported by Nuxt
 	this.nuxt.hook('components:dirs', dirs => {
 		dirs.push({
 			path: join(__dirname, './components'),
-			prefix: 'modal',
+			prefix: 'cloak-modal',
+			level: 2,
 		})
 	})
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"repository": "git@github.com:BKWLD/cloak-modal.git",
 	"author": "Bukwild <info@bukwild.com>",
 	"license": "MIT",
-	"main": "components/cloak-modal.js",
+	"main": "nuxt.js",
 	"scripts": {
 		"dev": "nuxt dev demo",
 		"build": "nuxt build demo",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10684,7 +10684,7 @@ webpack-dev-middleware@^4.2.0:
     range-parser "^1.2.1"
     schema-utils "^3.0.0"
 
-"webpack-graphql-loader@github:gpoitch/graphql-loader#gp/refresh", webpack-graphql-loader@gpoitch/graphql-loader#gp/refresh:
+webpack-graphql-loader@gpoitch/graphql-loader#gp/refresh:
   version "1.0.2"
   resolved "https://codeload.github.com/gpoitch/graphql-loader/tar.gz/42f0f990a6132ccd5e284d0e6cfeade12728dba2"
   dependencies:


### PR DESCRIPTION
@mattaebersold this contains some changes I made so I could package this for use on RH.  The main difference is how that test modal uses `cloak-modal`.  I like the idea of the project-specific modal component using `cloak-modal` as it's root element, like I'm doing now here:

```vue
<template lang='pug'>
  cloak-modal(v-bind='$props')
    h3 Modal Contents
    p Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lacinia venenatis lectus, ac cursus ligula. Sed nec enim urna. Nullam congue eros elit, eget consectetur nunc accumsan quis.
    button Button
</template>
```